### PR TITLE
Expose function with same logic as LoadEnvVarsFromConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* Expose new `loadEnvVarsFromConfig` function to use instead of `EnvVarLoaderProvider`.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* Deprecate `EnvVarLoaderProvider`. Use `loadEnvVarsFromConfig` instead.
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [3.1.0] - 2024-07-22
 ### Added
 * Support `laminas/laminas-servicemanager` >=4.2

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -9,6 +9,7 @@ use Laminas\Stdlib\Glob;
 
 use function getenv;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_numeric;
 use function is_scalar;
@@ -42,6 +43,21 @@ function parseEnvVar(string $value): string|int|bool|null
         'null', '(null)' => null,
         default => is_numeric($trimmedValue) ? (int) $trimmedValue : $trimmedValue,
     };
+}
+
+/**
+ * Loads config from $configPath, then puts all its values as env vars if they are not yet defined
+ */
+function loadEnvVarsFromConfig(string $configPath, ?array $allowedEnvVars = null): void
+{
+    $config = loadConfigFromGlob($configPath);
+    foreach ($config as $envVar => $value) {
+        if ($allowedEnvVars !== null && ! in_array($envVar, $allowedEnvVars, true)) {
+            continue;
+        }
+
+        putNotYetDefinedEnv($envVar, $value);
+    }
 }
 
 function putNotYetDefinedEnv(string $key, mixed $value): void

--- a/src/ConfigAggregator/EnvVarLoaderProvider.php
+++ b/src/ConfigAggregator/EnvVarLoaderProvider.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Config\ConfigAggregator;
 
-use function in_array;
-use function Shlinkio\Shlink\Config\loadConfigFromGlob;
-use function Shlinkio\Shlink\Config\putNotYetDefinedEnv;
+use function Shlinkio\Shlink\Config\loadEnvVarsFromConfig;
 
+/** @deprecated Use loadEnvVarsFromConfig instead */
 class EnvVarLoaderProvider
 {
     public function __construct(private readonly string $configPath, private readonly ?array $allowedEnvVars = null)
@@ -16,15 +15,7 @@ class EnvVarLoaderProvider
 
     public function __invoke(): array
     {
-        $config = loadConfigFromGlob($this->configPath);
-        foreach ($config as $envVar => $value) {
-            if ($this->allowedEnvVars !== null && ! in_array($envVar, $this->allowedEnvVars, true)) {
-                continue;
-            }
-
-            putNotYetDefinedEnv($envVar, $value);
-        }
-
+        loadEnvVarsFromConfig($this->configPath, $this->allowedEnvVars);
         return [];
     }
 }

--- a/test/Functions/LoadEnvVarsFromConfigTest.php
+++ b/test/Functions/LoadEnvVarsFromConfigTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace ShlinkioTest\Shlink\Config\ConfigAggregator;
+namespace ShlinkioTest\Shlink\Config\Functions;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Shlinkio\Shlink\Config\ConfigAggregator\EnvVarLoaderProvider;
 
 use function getenv;
 use function putenv;
 use function Shlinkio\Shlink\Config\env;
+use function Shlinkio\Shlink\Config\loadEnvVarsFromConfig;
 
-class EnvVarLoaderProviderTest extends TestCase
+class LoadEnvVarsFromConfigTest extends TestCase
 {
     private const VALID_ENV_VARS = [
         'BAR',
@@ -37,14 +37,11 @@ class EnvVarLoaderProviderTest extends TestCase
     #[Test]
     public function putsExpectedEnvVars(): void
     {
-        $provider = new EnvVarLoaderProvider(
+        loadEnvVarsFromConfig(
             __DIR__ . '/../../test-resources/generated_config.php',
             self::VALID_ENV_VARS,
         );
 
-        $result = $provider();
-
-        self::assertEquals([], $result);
         self::assertEquals('true', getenv('BAR'));
         self::assertTrue(env('BAR'));
         self::assertEquals('false', getenv('BAZ'));


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2208

Expose function that can be used instead of LoadEnvVarsFromConfig, but explicitly invoked to know when are env vars safe to read.