### PR TITLE
Make loadEnvVarsFromConfig skip null env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [3.2.1] - 2024-10-17
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Fix regression where `loadEnvVarsFromConfig` defines env vars with null value as empty instead of skipping them entirely.
+
+
 ## [3.2.0] - 2024-10-14
 ### Added
 * Expose new `loadEnvVarsFromConfig` function to use instead of `EnvVarLoaderProvider`.

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -48,11 +48,11 @@ function parseEnvVar(string $value): string|int|bool|null
 /**
  * @param string|string[]|int|int[]|bool|null $value
  */
-function formatEnvVarValue(string|int|bool|array|null $value): string
+function formatEnvVarValueOrNull(string|int|bool|array|null $value): string|null
 {
     $isArray = is_array($value);
     if (! $isArray && ! is_scalar($value)) {
-        return '';
+        return null;
     }
 
     return $isArray ? implode(',', $value) : match ($value) {
@@ -60,6 +60,14 @@ function formatEnvVarValue(string|int|bool|array|null $value): string
         false => 'false',
         default => (string) $value,
     };
+}
+
+/**
+ * @param string|string[]|int|int[]|bool|null $value
+ */
+function formatEnvVarValue(string|int|bool|array|null $value): string
+{
+    return formatEnvVarValueOrNull($value) ?? '';
 }
 
 /**
@@ -83,7 +91,11 @@ function putNotYetDefinedEnv(string $key, mixed $value): void
         return;
     }
 
-    $formattedValue = formatEnvVarValue($value);
+    $formattedValue = formatEnvVarValueOrNull($value);
+    if ($formattedValue === null) {
+        return;
+    }
+
     putenv(sprintf('%s=%s', $key, $formattedValue));
 }
 

--- a/test/Functions/FormatEnvVarValueTest.php
+++ b/test/Functions/FormatEnvVarValueTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 use function Shlinkio\Shlink\Config\formatEnvVarValue;
+use function Shlinkio\Shlink\Config\formatEnvVarValueOrNull;
 
 class FormatEnvVarValueTest extends TestCase
 {
@@ -23,5 +24,6 @@ class FormatEnvVarValueTest extends TestCase
     public function valuesAreFormattedAsExpected(string|int|bool|array|null $value, string $expectedResult): void
     {
         self::assertEquals($expectedResult, formatEnvVarValue($value));
+        self::assertEquals($value === null ? null : $expectedResult, formatEnvVarValueOrNull($value));
     }
 }

--- a/test/Functions/LoadEnvVarsFromConfigTest.php
+++ b/test/Functions/LoadEnvVarsFromConfigTest.php
@@ -53,6 +53,6 @@ class LoadEnvVarsFromConfigTest extends TestCase
         self::assertFalse(getenv('foo2'));
         self::assertEquals('3', getenv('NUMBER'));
         self::assertEquals(3, env('NUMBER'));
-        self::assertEquals('', env('NULL'));
+        self::assertNull(env('NULL'));
     }
 }


### PR DESCRIPTION
Fix regression introduced in https://github.com/shlinkio/shlink-config/pull/37, which made config entries with `null` value to be promoted as env vars with `''` value when calling `loadEnvVarsFromConfig`.

Relates to https://github.com/shlinkio/shlink/issues/2225