### PR TITLE
Deprecate ValinorConfigFactory and make cuyz/valinor optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ on:
 jobs:
   ci:
     uses: shlinkio/github-actions/.github/workflows/php-lib-ci.yml@main
-    with:
-      coverage-driver: 'xdebug'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Changed
-* Switch to xdebug for code coverage reports, as pcov is not marking functions as covered
+* Switch to xdebug for code coverage reports, as pcov is not marking functions as covered.
+* Make `cuyz/valinor` an optional dependency, required only if you plan to use `ValinorConfigFactory`.
 
 ### Deprecated
-* *Nothing*
+* Deprecate `ValinorConfigFactory`.
 
 ### Removed
 * *Nothing*

--- a/README.md
+++ b/README.md
@@ -21,20 +21,3 @@ Install this tool using [composer](https://getcomposer.org/).
 * `loadConfigFromGlob`: Function which expects a glob pattern and loads and merges all config files that match it.
 * `EnvVarLoaderProvider`: A config provider which loads the entries of the loaded config into env vars and always returns empty. Designed to be the first config provider in the pipeline.
 * `DottedAccessConfigAbstractFactory`: An abstract factory that lets any config param to be fetched as a service by using the `config.foo.bar` notation.
-* `ValinorConfigFactory`: A PSR-11 factory that lets you map arbitrary objects from arrays, using [cuyz/valinior](https://github.com/CuyZ/Valinor).
-
-    In order to use it, you have to register the object to map as a service, and the ValinorConfigFactory with static access using the service that returns the raw array with the data as the static method name:
-
-    ```php
-    <?php
-
-    declare(strict_types=1);
-
-    return [
-        MyCoolOptions::class => [ValinorConfigFactory::class, 'config.foo.options'],
-    ];
-    ```
-
-    It is useful to combine this factory with the `DottedAccessConfigAbstractFactory`.
-
-    The mapping will be done with cache if a `Psr\SimpleCache\CacheInterface` service is found.

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "cuyz/valinor": "^1.12",
         "laminas/laminas-config": "^3.9",
         "laminas/laminas-servicemanager": "^4.2 || ^3.22"
     },
+    "suggest": {
+        "cuyz/valinor": "To be able to use ValinorConfigFactory"
+    },
     "require-dev": {
+        "cuyz/valinor": "^1.12",
         "devster/ubench": "^2.1",
         "phpstan/phpstan": "^1.11",
         "phpunit/phpunit": "^11.3",

--- a/src/Factory/ValinorConfigFactory.php
+++ b/src/Factory/ValinorConfigFactory.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\MapperBuilder;
 use Psr\Container\ContainerInterface;
 use Psr\SimpleCache\CacheInterface;
 
+/** @deprecated */
 class ValinorConfigFactory
 {
     public static function __callStatic(string $name, array $arguments): mixed


### PR DESCRIPTION
Shlink is moving into an env-var-based approach for local configs, so options objects are going to be hydrated differently https://github.com/shlinkio/shlink/pull/2224

That makes the `ValinorConfigFactory` less useful, so this PR marks it as deprecated and makes the `cuyz/valinor` dependency optional.