### PR TITLE
Feature/remove laminas config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Removed
-* *Nothing*
+* Remove dependency on `laminas/laminas-config`.
 
 ### Fixed
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "laminas/laminas-config": "^3.9",
-        "laminas/laminas-servicemanager": "^4.2 || ^3.22"
+        "laminas/laminas-servicemanager": "^4.2 || ^3.22",
+        "laminas/laminas-stdlib": "^3.20"
     },
     "suggest": {
         "cuyz/valinor": "To be able to use ValinorConfigFactory"

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -22,8 +22,10 @@ use const PHP_SAPI;
 
 function loadConfigFromGlob(string $globPattern): array
 {
+    $files = Glob::glob($globPattern, Glob::GLOB_BRACE);
+
     /** @var array $config */
-    $config = Factory::fromFiles(Glob::glob($globPattern, Glob::GLOB_BRACE));
+    $config = Factory::fromFiles($files);
     return $config;
 }
 

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Config;
 
-use Laminas\Config\Factory;
+use Laminas\Stdlib\ArrayUtils;
 use Laminas\Stdlib\Glob;
 
+use function file_exists;
 use function getenv;
 use function implode;
 use function in_array;
@@ -15,6 +16,7 @@ use function is_numeric;
 use function is_scalar;
 use function putenv;
 use function sprintf;
+use function str_ends_with;
 use function strtolower;
 use function trim;
 
@@ -22,10 +24,17 @@ use const PHP_SAPI;
 
 function loadConfigFromGlob(string $globPattern): array
 {
+    $config = [];
     $files = Glob::glob($globPattern, Glob::GLOB_BRACE);
 
-    /** @var array $config */
-    $config = Factory::fromFiles($files);
+    foreach ($files as $file) {
+        if (! str_ends_with($file, '.php') || ! file_exists($file)) {
+            continue;
+        }
+
+        $config = ArrayUtils::merge($config, include $file);
+    }
+
     return $config;
 }
 

--- a/test-resources/configs/bar_config.global.php
+++ b/test-resources/configs/bar_config.global.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'bar' => [
+        'number' => 123,
+        'array' => [1, 2, 3]
+    ],
+
+];

--- a/test-resources/configs/foo_config.global.php
+++ b/test-resources/configs/foo_config.global.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'foo' => [
+        'something' => true,
+        'else' => 'bar',
+    ],
+
+];

--- a/test-resources/configs/foo_config.local.php
+++ b/test-resources/configs/foo_config.local.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'foo' => [
+        'something' => false,
+    ],
+
+];

--- a/test/Functions/LoadConfigFromGlobTest.php
+++ b/test/Functions/LoadConfigFromGlobTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShlinkioTest\Shlink\Config\Functions;
 
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 use function Shlinkio\Shlink\Config\loadConfigFromGlob;
@@ -22,8 +23,18 @@ class LoadConfigFromGlobTest extends TestCase
             ],
             'bar' => [
                 'number' => 123,
-                'array' => [1, 2, 3]
+                'array' => [1, 2, 3],
             ],
         ], $result);
+    }
+
+    #[Test]
+    #[TestWith([__DIR__ . '/../../test-resources/configs/does-not-exist.php'])]
+    #[TestWith([__DIR__ . '/../../composer.json'])]
+    #[TestWith(['does-not-exist.php'])]
+    public function nonPhpFilesAreNonExistingFilesAreSkipped(string $globPattern): void
+    {
+        $result = loadConfigFromGlob($globPattern);
+        self::assertEmpty($result);
     }
 }

--- a/test/Functions/LoadConfigFromGlobTest.php
+++ b/test/Functions/LoadConfigFromGlobTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Config\Functions;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function Shlinkio\Shlink\Config\loadConfigFromGlob;
+
+class LoadConfigFromGlobTest extends TestCase
+{
+    #[Test]
+    public function expectedConfigIsProduced(): void
+    {
+        $result = loadConfigFromGlob(__DIR__ . '/../../test-resources/configs/*.{global,local}.php');
+        self::assertEquals([
+            'foo' => [
+                'something' => false,
+                'else' => 'bar',
+            ],
+            'bar' => [
+                'number' => 123,
+                'array' => [1, 2, 3]
+            ],
+        ], $result);
+    }
+}


### PR DESCRIPTION
According to [the latest laminas steering committee meeting](https://getlaminas.org/blog/2024-11-18-summary-of-the-meeting-in-november-2024.html), some packages are likely going to be abandoned, being `laminas/laminas-config` one of them.

This PR removes the dependency on that package.